### PR TITLE
add verification before addReview

### DIFF
--- a/app/db_init.py
+++ b/app/db_init.py
@@ -15,6 +15,7 @@ cur.execute('DROP TABLE IF EXISTS product2reviews;')
 cur.execute('DROP TABLE IF EXISTS users;')
 cur.execute('DROP TABLE IF EXISTS reviews;')
 cur.execute('DROP TABLE IF EXISTS products;')
+cur.execute('DROP TABLE IF EXISTS review_histories;')
 cur.execute('''
     CREATE TABLE users (id serial PRIMARY KEY,
                         username varchar (50) NOT NULL,

--- a/app/static/js/edit_review.js
+++ b/app/static/js/edit_review.js
@@ -5,7 +5,7 @@ $(document).ready(function(){
     if (msg === "Please Login First!") {
 
         setTimeout("window.location.href='/login'", 1000);
-    } else if (msg === "Please fill out the form !" || msg === "You have successfully edited a review!"){
+    } else if (msg === "Please fill out the form !" || msg === "You have successfully edited a review!" || msg === "Edit failed! You have not purchased this item!"){
         setTimeout("window.location.replace('/reviews/edit/' + review['Id'])", 500);
     }
     var form = document.getElementById('editReviewForm');

--- a/app/web3_config.py
+++ b/app/web3_config.py
@@ -2,95 +2,147 @@
 # in development, please set these values to be your own values
 
 # this should be changed for your own
-CONTRACT_ADDRESS = '0x17b2c4a7AB870F5274d425DAB076d0D5d6cbbd5c'
+CONTRACT_ADDRESS = '0x83835a649162888EfAbA72CfB380D90E36f44851'
 
 # do not need to change it
 CONTRACT_ABI = [
-    {
-        "inputs": [],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "string",
-                "name": "message",
-                "type": "string"
-            }
-        ],
-        "name": "Log",
-        "type": "event"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "message",
-                "type": "string"
-            }
-        ],
-        "name": "addReview",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getBalance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address payable",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address payable",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "withdraw",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "stateMutability": "payable",
-        "type": "receive"
-    }
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "buyer",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "product_id",
+				"type": "uint256"
+			}
+		],
+		"name": "addPurchase",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "user_address",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "product_id",
+				"type": "uint256"
+			},
+			{
+				"internalType": "string",
+				"name": "message",
+				"type": "string"
+			}
+		],
+		"name": "addReview",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": False,
+		"inputs": [
+			{
+				"indexed": True,
+				"internalType": "address",
+				"name": "sender",
+				"type": "address"
+			},
+			{
+				"indexed": False,
+				"internalType": "string",
+				"name": "message",
+				"type": "string"
+			}
+		],
+		"name": "Log",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address payable",
+				"name": "_to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "_amount",
+				"type": "uint256"
+			}
+		],
+		"name": "withdraw",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"stateMutability": "payable",
+		"type": "receive"
+	},
+	{
+		"inputs": [],
+		"name": "getBalance",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "owner",
+		"outputs": [
+			{
+				"internalType": "address payable",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "purchase",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
 ]
 
 # your URL for web3 test server


### PR DESCRIPTION
For simplicity, I automatically add the purchase history for every newly registered account with product_id 1 and 3.

A review can only be posted if and only if it has an associated purchase history stored on the contract.